### PR TITLE
arduino-i2c-scd4x 1.0.0 support

### DIFF
--- a/.github/workflows/arduino_build.yml
+++ b/.github/workflows/arduino_build.yml
@@ -16,7 +16,7 @@ jobs:
           platforms: |
             - name: esp32:esp32
               source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
-              version: 3.1.0
+              version: 3.1.3
           libraries: |
             - name: Adafruit DotStar
             - name: Sensirion Core

--- a/OpenCO2_Sensor.ino
+++ b/OpenCO2_Sensor.ino
@@ -10,7 +10,7 @@
    - WiFiManager: https://github.com/tzapu/WiFiManager
    - ArduinoMqttClient (if MQTT is defined)
 */
-#define VERSION "v5.5"
+#define VERSION "v5.6"
 
 #define HEIGHT_ABOVE_SEA_LEVEL 50             // Berlin
 #define TZ_DATA "CET-1CEST,M3.5.0,M10.5.0/3"  // Europe/Berlin time zone from https://github.com/nayarsystems/posix_tz_db/blob/master/zones.csv
@@ -92,7 +92,8 @@ RTC_DATA_ATTR float maxBatteryVoltage;
 
 /* TEST_MODE */
 RTC_DATA_ATTR bool TEST_MODE;
-RTC_DATA_ATTR uint16_t sensorStatus, serial0, serial1, serial2;
+RTC_DATA_ATTR uint16_t sensorStatus;
+RTC_DATA_ATTR uint64_t serialNumber;
 
 RTC_DATA_ATTR uint16_t co2 = 400;
 RTC_DATA_ATTR float temperature = 0.0f, humidity = 0.0f;
@@ -363,7 +364,6 @@ void initOnce() {
   preferences.end();
 
   scd4x.stopPeriodicMeasurement();  // stop potentially previously started measurement
-  uint64_t serialNumber;
   scd4x.getSerialNumber(serialNumber);
   scd4x.setSensorAltitude(HEIGHT_ABOVE_SEA_LEVEL);
   scd4x.setAutomaticSelfCalibrationEnabled(1); // Or use setAutomaticSelfCalibrationTarget if needed

--- a/OpenCO2_Sensor.ino
+++ b/OpenCO2_Sensor.ino
@@ -71,9 +71,9 @@ Adafruit_DotStar strip(1, 40, 39, DOTSTAR_BRG);  // numLEDs, DATAPIN, CLOCKPIN
 
 /* scd4x */
 #include <Arduino.h>
-#include <SensirionI2CScd4x.h>
+#include <SensirionI2cScd4x.h>
 #include <Wire.h>
-SensirionI2CScd4x scd4x;
+SensirionI2cScd4x scd4x;
 
 
 #ifndef ARDUINO_USB_MODE
@@ -363,9 +363,10 @@ void initOnce() {
   preferences.end();
 
   scd4x.stopPeriodicMeasurement();  // stop potentially previously started measurement
-  scd4x.getSerialNumber(serial0, serial1, serial2);
+  uint64_t serialNumber;
+  scd4x.getSerialNumber(serialNumber);
   scd4x.setSensorAltitude(HEIGHT_ABOVE_SEA_LEVEL);
-  scd4x.setAutomaticSelfCalibration(1);
+  scd4x.setAutomaticSelfCalibrationEnabled(1); // Or use setAutomaticSelfCalibrationTarget if needed
   scd4x.setTemperatureOffset(getTempOffset());
   scd4x.startPeriodicMeasurement();
 
@@ -749,7 +750,7 @@ void setup() {
 
   /* scd4x */
   Wire.begin(33, 34);  // green, yellow
-  scd4x.begin(Wire);
+  scd4x.begin(Wire, 0x62); // 0x62 is the default I2C address for SCD4x
 
   USB.onEvent(usbEventCallback);
   usbmsc.isWritable(true);
@@ -812,7 +813,7 @@ void loop() {
   }
 
   bool isDataReady = false;
-  uint16_t ready_error = scd4x.getDataReadyFlag(isDataReady);
+  uint16_t ready_error = scd4x.getDataReadyStatus(isDataReady);
   if (ready_error || !isDataReady) {
     if (BatteryMode && comingFromDeepSleep) goto_deep_sleep(DEEP_SLEEP_TIME/2);
     else goto_light_sleep(LIGHT_SLEEP_TIME/2);

--- a/epd_abstraction.ino
+++ b/epd_abstraction.ino
@@ -1165,19 +1165,17 @@ void displayWiFiStrengh() {
 }
 
 void displayinfo() {
-  extern uint16_t serial0, serial1, serial2;
+  extern uint64_t serialNumber;
   Paint_Clear(WHITE);
 
   Paint_DrawString_EN(0, 1, "MAC Address:", &Font16, WHITE, BLACK);
   Paint_DrawString_EN(0, 17, WiFi.macAddress().c_str(), &Font16, WHITE, BLACK);
 
   char serial[19] = "SCD4x:";
-  char hex[5];
-  sprintf(hex, "%04X", serial0);
+  char hex[9];
+  sprintf(hex, "%04X", (uint32_t)(serialNumber >> 32));
   strcat(serial, hex);
-  sprintf(hex, "%04X", serial1);
-  strcat(serial, hex);
-  sprintf(hex, "%04X", serial2);
+  sprintf(hex, "%08X", (uint32_t)(serialNumber & 0xFFFFFFFF));
   strcat(serial, hex);
   Paint_DrawString_EN(0, 33, serial, &Font16, WHITE, BLACK);
 
@@ -1245,7 +1243,7 @@ void displayWriteError(char errorMessage[256]){
 
 /* TEST_MODE */
 void displayWriteTestResults(float voltage, uint16_t sensorStatus) {
-  extern uint16_t serial0, serial1, serial2;
+  extern uint64_t serialNumber;
   char batteryvolt[8] = "";
   dtostrf(voltage, 1, 3, batteryvolt);
   char volt[10] = "V";
@@ -1281,17 +1279,14 @@ void displayWriteTestResults(float voltage, uint16_t sensorStatus) {
   Paint_DrawString_EN(0, 176, mac, &Font12, WHITE, BLACK);
 
   char serial[20] = "Serial:";
-  char hex[5];
-  sprintf(hex, "%04X", serial0);
-  Serial.print(hex);
+  Serial.print("0x");
+  Serial.print((uint32_t)(serialNumber >> 32), HEX);
+  Serial.println((uint32_t)(serialNumber & 0xFFFFFFFF), HEX);
+  char hex[9];
+  sprintf(hex, "%04X", (uint32_t)(serialNumber >> 32));
   strcat(serial, hex);
-  sprintf(hex, "%04X", serial1);
-  Serial.print(hex);
+  sprintf(hex, "%08X", (uint32_t)(serialNumber & 0xFFFFFFFF));
   strcat(serial, hex);
-  sprintf(hex, "%04X", serial2);
-  Serial.println(hex);
-  strcat(serial, hex);
-  //Serial.print('\n');
   Paint_DrawString_EN(0, 188, serial, &Font12, WHITE, BLACK);
 
   Paint_DrawNum(158, 180, (int32_t)refreshes, &Font16, BLACK, WHITE);


### PR DESCRIPTION
modified a few lines to add arduino-i2c-scd4x 1.0.0 (2025/01/31) support due to breaking changes in that release.

https://github.com/Sensirion/arduino-i2c-scd4x/blob/master/CHANGELOG.md

Breaking changes

The file and class name has changed from SensirionI2CScd4x to SensirionI2cScd4x (the "c" in I2c is now in lower case)

begin(TwoWire& i2cBus, uint8_t i2cAddress); now takes a second argument for the i2c address

all methods that have been named xxxTicks are now named xxxRaw

getDataReadyFlag has been renamed to getDataReadyStatus

get/setAmbientPressure(uint32_t& aAmbientPressure); now takes the ambient pressure in Pa as uint32_t

getSerialNumber now returns uint64_t