### PR TITLE
esp_sleep_enable_ext1_wakeup_io function fix

### DIFF
--- a/OpenCO2_Sensor.ino
+++ b/OpenCO2_Sensor.ino
@@ -459,7 +459,7 @@ void goto_deep_sleep(int ms) {
   /* Wakeup by IO0 button */
   rtc_gpio_pullup_en(BUTTON);
   rtc_gpio_pulldown_dis(BUTTON);
-  esp_sleep_enable_ext1_wakeup_io((1ULL << BUTTON), ESP_EXT1_WAKEUP_ANY_LOW);
+  esp_sleep_enable_ext1_wakeup((1ULL << BUTTON), ESP_EXT1_WAKEUP_ANY_LOW);
 
   /* Keep LED enabled */
   if (LEDonBattery) gpio_hold_en(LED_POWER);


### PR DESCRIPTION
v5.0 used esp_sleep_enable_ext1_wakeup
v5.5 uses esp_sleep_enable_ext1_wakeup_io

i could not escape TEST_MODE after compiling and pushing a new build (with erase all flash before upload enabled)

if it was a me only problem that's fine - if not, switching back to the 5.0 function fixed it for me